### PR TITLE
chore: fix EditorConfig lint errors (issue #6653)

### DIFF
--- a/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-list-item-spacing/README.md
+++ b/lib/node_modules/@stdlib/_tools/eslint/rules/jsdoc-list-item-spacing/README.md
@@ -108,7 +108,7 @@ function beep() {
 }
 ```
 
-The [rule][eslint-rules] may be configured using the same options as supported by [remark][remark-lint-list-item-spacing]. 
+The [rule][eslint-rules] may be configured using the same options as supported by [remark][remark-lint-list-item-spacing].
 
 </section>
 


### PR DESCRIPTION
Resolves #6653

## Description

> What is the purpose of this pull request?

This pull request:

-  Removes trailing whitespace from `README.md` at line 111 to fix EditorConfig lint error.

## Related Issues

> Does this pull request have any related issues?

This pull request:

-   resolves #6653

## Questions

> Any questions for reviewers of this pull request?

No.

## Other

> Any other information relevant to this pull request? This may include screenshots, references, and/or implementation notes.

No.

## Checklist

> Please ensure the following tasks are completed before submitting this pull request.

-   [x] Read, understood, and followed the [contributing guidelines][contributing].

* * *

@stdlib-js/reviewers

[contributing]: https://github.com/stdlib-js/stdlib/blob/develop/CONTRIBUTING.md
